### PR TITLE
Revert "Fix image builds"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,7 @@
-FROM golang:1.20.5 AS builder
+FROM gcr.io/distroless/static
 
-COPY . /src
-WORKDIR /src
-
-# Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o bin/location-api .
-
-# Pass in name as --build-arg
-FROM gcr.io/distroless/static:nonroot
-# `nonroot` coming from distroless
-USER 65532:65532
-
-COPY  --from=builder /src/bin/location-api /location-api
+# Copy the binary that goreleaser built
+COPY location-api /location-api
 
 # Run the web service on container startup.
 ENTRYPOINT ["/location-api"]


### PR DESCRIPTION
Reverts infratographer/location-api#20

This isn't actually needed as goreleaser is handling the artifact generation.